### PR TITLE
Replace winrt::hresult with HRESULT in errors.ixx

### DIFF
--- a/netpbm-wic-codec.sln.DotSettings
+++ b/netpbm-wic-codec.sln.DotSettings
@@ -9,6 +9,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=endian/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=graymap/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=hkey/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=hresult/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Inproc/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=IWIC/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lossless/@EntryIndexedValue">True</s:Boolean>

--- a/src/errors.ixx
+++ b/src/errors.ixx
@@ -7,69 +7,74 @@ module;
 
 export module errors;
 
+import <olectl.h>;
 
-export
-{
-    inline constexpr winrt::hresult error_ok{S_OK};
-    inline constexpr winrt::hresult error_fail{E_FAIL};
-    inline constexpr winrt::hresult error_pointer{E_POINTER};
-    inline constexpr winrt::hresult error_no_aggregation{static_cast<winrt::hresult>(CLASS_E_NOAGGREGATION)};
-    inline constexpr winrt::hresult error_class_not_available{static_cast<winrt::hresult>(CLASS_E_CLASSNOTAVAILABLE)};
-    inline constexpr winrt::hresult error_invalid_argument{static_cast<winrt::hresult>(E_INVALIDARG)};
+export {
+
+inline constexpr HRESULT error_ok{S_OK};
+inline constexpr HRESULT error_fail{E_FAIL};
+inline constexpr HRESULT error_pointer{E_POINTER};
+inline constexpr HRESULT error_no_aggregation{CLASS_E_NOAGGREGATION};
+inline constexpr HRESULT error_class_not_available{CLASS_E_CLASSNOTAVAILABLE};
+inline constexpr HRESULT error_invalid_argument{E_INVALIDARG};
+
+namespace self_registration {
+
+inline constexpr HRESULT error_class{SELFREG_E_CLASS};
+
 }
 
+namespace wincodec {
 
-export namespace wincodec {
-
-inline constexpr winrt::hresult error_palette_unavailable{static_cast<winrt::hresult>(WINCODEC_ERR_PALETTEUNAVAILABLE)};
-inline constexpr winrt::hresult error_unsupported_operation{static_cast<winrt::hresult>(WINCODEC_ERR_UNSUPPORTEDOPERATION)};
-inline constexpr winrt::hresult error_codec_no_thumbnail{static_cast<winrt::hresult>(WINCODEC_ERR_CODECNOTHUMBNAIL)};
-inline constexpr winrt::hresult error_frame_missing{static_cast<winrt::hresult>(WINCODEC_ERR_FRAMEMISSING)};
-inline constexpr winrt::hresult error_not_initialized{static_cast<winrt::hresult>(WINCODEC_ERR_NOTINITIALIZED)};
-inline constexpr winrt::hresult error_wrong_state{static_cast<winrt::hresult>(WINCODEC_ERR_WRONGSTATE)};
-inline constexpr winrt::hresult error_unsupported_pixel_format{
-    static_cast<winrt::hresult>(WINCODEC_ERR_UNSUPPORTEDPIXELFORMAT)};
-inline constexpr winrt::hresult error_codec_too_many_scan_lines{
-    static_cast<winrt::hresult>(WINCODEC_ERR_CODECTOOMANYSCANLINES)};
-inline constexpr winrt::hresult error_component_not_found{static_cast<winrt::hresult>(WINCODEC_ERR_COMPONENTNOTFOUND)};
-inline constexpr winrt::hresult error_bad_header{static_cast<winrt::hresult>(WINCODEC_ERR_BADHEADER)};
-inline constexpr winrt::hresult error_bad_image{static_cast<winrt::hresult>(WINCODEC_ERR_BADIMAGE)};
-inline constexpr winrt::hresult error_stream_not_available{static_cast<winrt::hresult>(WINCODEC_ERR_STREAMNOTAVAILABLE)};
-inline constexpr winrt::hresult error_stream_read{static_cast<winrt::hresult>(WINCODEC_ERR_STREAMREAD)};
+inline constexpr HRESULT error_palette_unavailable{WINCODEC_ERR_PALETTEUNAVAILABLE};
+inline constexpr HRESULT error_unsupported_operation{WINCODEC_ERR_UNSUPPORTEDOPERATION};
+inline constexpr HRESULT error_codec_no_thumbnail{WINCODEC_ERR_CODECNOTHUMBNAIL};
+inline constexpr HRESULT error_frame_missing{WINCODEC_ERR_FRAMEMISSING};
+inline constexpr HRESULT error_not_initialized{WINCODEC_ERR_NOTINITIALIZED};
+inline constexpr HRESULT error_wrong_state{WINCODEC_ERR_WRONGSTATE};
+inline constexpr HRESULT error_unsupported_pixel_format{WINCODEC_ERR_UNSUPPORTEDPIXELFORMAT};
+inline constexpr HRESULT error_codec_too_many_scan_lines{WINCODEC_ERR_CODECTOOMANYSCANLINES};
+inline constexpr HRESULT error_component_not_found{WINCODEC_ERR_COMPONENTNOTFOUND};
+inline constexpr HRESULT error_bad_header{WINCODEC_ERR_BADHEADER};
+inline constexpr HRESULT error_bad_image{WINCODEC_ERR_BADIMAGE};
+inline constexpr HRESULT error_stream_not_available{WINCODEC_ERR_STREAMNOTAVAILABLE};
+inline constexpr HRESULT error_stream_read{WINCODEC_ERR_STREAMREAD};
 
 } // namespace wincodec
 
-export inline void check_hresult(const winrt::hresult result, const winrt::hresult result_to_throw)
+inline void check_hresult(const winrt::hresult result, const winrt::hresult result_to_throw)
 {
     if (result < 0)
         throw_hresult(result_to_throw);
 }
 
-export inline constexpr bool failed(const winrt::hresult result) noexcept
+[[nodiscard]] constexpr bool failed(const winrt::hresult result) noexcept
 {
     return result < 0;
 }
 
-export template<typename T>
+template<typename T>
 T* check_in_pointer(_In_ T* pointer)
 {
     if (!pointer)
-        throw_hresult(error_invalid_argument);
+        winrt::throw_hresult(error_invalid_argument);
 
     return pointer;
 }
 
-export template<typename T>
+template<typename T>
 T* check_out_pointer(T* pointer)
 {
     if (!pointer)
-        throw_hresult(error_pointer);
+        winrt::throw_hresult(error_pointer);
 
     return pointer;
 }
 
-export inline void check_condition(const bool condition, const winrt::hresult result_to_throw)
+inline void check_condition(const bool condition, const winrt::hresult result_to_throw)
 {
     if (!condition)
         throw_hresult(result_to_throw);
+}
+
 }

--- a/src/macros.h
+++ b/src/macros.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Victor Derks.
+// Copyright (c) Victor Derks.
 // SPDX-License-Identifier: MIT
 
 #pragma once
@@ -14,6 +14,11 @@
 // Reported to Microsoft:
 // https://developercommunity.visualstudio.com/content/problem/804372/c26447-false-positive-when-using-stdscoped-lock-ev.html
 #define SUPPRESS_FALSE_WARNING_C26447_NEXT_LINE SUPPRESS_WARNING_NEXT_LINE(26447)
+
+// returning uninitialized memory (false positive)
+// Reported to Microsoft (but was closed due to lower priority):
+// https://developercommunity.visualstudio.com/t/static-analysis-emits-a-false-positive-c6101-error/804429
+#define SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE SUPPRESS_WARNING_NEXT_LINE(6101)
 
 
 #ifdef NDEBUG

--- a/src/netpbm_bitmap_decoder.cpp
+++ b/src/netpbm_bitmap_decoder.cpp
@@ -120,8 +120,7 @@ public:
 
         // Keep the initial design simple: no support for container-level metadata.
         // Note: Conceptual, comments from the NetPbm file could converted into metadata.
-        constexpr HRESULT hr = wincodec::error_unsupported_operation;
-        return hr;
+        return wincodec::error_unsupported_operation;
     }
 
     HRESULT __stdcall GetPreview([[maybe_unused]] _Outptr_ IWICBitmapSource** bitmap_source) noexcept override
@@ -129,8 +128,7 @@ public:
         TRACE("%p netpbm_bitmap_decoder::GetPreview (not supported), bitmap_source address=%p\n", this, bitmap_source);
 
         // The Netpbm format doesn't support storing previews in the file format.
-        constexpr HRESULT hr = wincodec::error_unsupported_operation;
-        return hr;
+        return wincodec::error_unsupported_operation;
     }
 
     HRESULT __stdcall GetColorContexts([[maybe_unused]] const uint32_t count,
@@ -156,8 +154,7 @@ public:
         TRACE("%p netpbm_bitmap_decoder::GetThumbnail (not supported), thumbnail address=%p\n", this, thumbnail);
 
         // The Netpbm format doesn't support storing thumbnails in the file format.
-        constexpr HRESULT hr{wincodec::error_codec_no_thumbnail};
-        return hr;
+        return wincodec::error_codec_no_thumbnail;
     }
 
     HRESULT __stdcall GetFrameCount(_Out_ uint32_t* count) noexcept override
@@ -218,8 +215,7 @@ private:
 };
 
 
-HRESULT create_netpbm_bitmap_decoder_factory(GUID const& interface_id, void** result)
+void create_netpbm_bitmap_decoder_factory(GUID const& interface_id, void** result)
 {
-    const HRESULT hr{winrt::make<class_factory<netpbm_bitmap_decoder>>()->QueryInterface(interface_id, result)};
-    return hr;
+    check_hresult(winrt::make<class_factory<netpbm_bitmap_decoder>>()->QueryInterface(interface_id, result));
 }

--- a/src/netpbm_bitmap_decoder.ixx
+++ b/src/netpbm_bitmap_decoder.ixx
@@ -5,4 +5,4 @@ export module netpbm_bitmap_decoder;
 import <winerror.h>;
 import <guiddef.h>;
 
-export HRESULT create_netpbm_bitmap_decoder_factory(GUID const& interface_id, void** result);
+export void create_netpbm_bitmap_decoder_factory(GUID const& interface_id, void** result);

--- a/src/netpbm_bitmap_frame_decode.cpp
+++ b/src/netpbm_bitmap_frame_decode.cpp
@@ -26,7 +26,7 @@ using winrt::to_hresult;
 
 namespace {
 
-std::pair<GUID, uint32_t> get_pixel_format_and_shift(const uint32_t bits_per_sample)
+[[nodiscard]] std::pair<GUID, uint32_t> get_pixel_format_and_shift(const uint32_t bits_per_sample)
 {
     switch (bits_per_sample)
     {
@@ -130,7 +130,7 @@ void pack_to_bytes(const span<const std::byte> source_pixels, std::byte* destina
     }
 }
 
-com_ptr<IWICBitmap> create_bitmap(_In_ IStream* source_stream, _In_ IWICImagingFactory* factory)
+[[nodiscard]] com_ptr<IWICBitmap> create_bitmap(_In_ IStream* source_stream, _In_ IWICImagingFactory* factory)
 {
     buffered_stream_reader stream_reader{source_stream};
     const pnm_header header{stream_reader};
@@ -243,7 +243,8 @@ HRESULT __stdcall netpbm_bitmap_frame_decode::CopyPalette(IWICPalette*) noexcept
 }
 
 // IWICBitmapFrameDecode : IWICBitmapSource
-SUPPRESS_WARNING_NEXT_LINE(6101)
+
+SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
 HRESULT __stdcall netpbm_bitmap_frame_decode::GetThumbnail(IWICBitmapSource**) noexcept
 {
     TRACE("%p netpbm_bitmap_frame_decode::GetThumbnail (not supported)\n", this);
@@ -265,7 +266,7 @@ catch (...)
     return to_hresult();
 }
 
-SUPPRESS_WARNING_NEXT_LINE(6101)
+SUPPRESS_FALSE_WARNING_C6101_NEXT_LINE
 HRESULT __stdcall netpbm_bitmap_frame_decode::GetMetadataQueryReader(
     [[maybe_unused]] IWICMetadataQueryReader** metadata_query_reader) noexcept
 {


### PR DESCRIPTION
Using winrt::hresult causes issues with SAL annotations. Use plain old HRESULT to get rid of false positive warnings. As WIC is using classic COM, this is not a problem (winerror.h must be included anyway).