### PR TITLE
Disable warning C5246 (when /all is enabled)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -64,13 +64,13 @@
         C5027 = 'type': move assignment operator was implicitly defined as deleted  [Just informational]
         C5039 = 'function': pointer or reference to potentially throwing function passed to extern C function under -EHc. [Just informational]
         C5045 = Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified [Just informational]
-        C5105 = macro expansion producing 'defined' has undefined behavior [Windows SDK not compatible with C++20]
         C5106 = macro redefined with different parameter names [Windows SDK not compatible with C++20]
+        C5246 = the initialization of a subobject should be wrapped in braces [Not needed for brace elision]
         C5262 = implicit fall-through occurs here; are you missing a break statement? [Too many false positives, Visual Studio 2022 17.4.0 Preview 3.0]
         C5264 = '': 'const' variable is not used [Too many false positives, Visual Studio 2022 17.4.0 Preview 3.0]
       -->
       <DisableSpecificWarnings>4005;5106</DisableSpecificWarnings>
-      <DisableSpecificWarnings Condition="'$(NETPBM_WIC_CODEC_ALL_WARNINGS)'!=''">4005;4061;4365;4464;4514;4571;4623;4625;4626;4668;4710;4711;4738;4774;4820;5026;5027;5039;5045;5105;5106;5262;5264</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(NETPBM_WIC_CODEC_ALL_WARNINGS)'!=''">4005;4061;4365;4464;4514;4571;4623;4625;4626;4668;4710;4711;4738;4774;4820;5026;5027;5039;5045;5106;5246;5262;5264</DisableSpecificWarnings>
 
       <!--
         __cplusplus = Tell MSVC to use the correct value for the __cplusplus macro

--- a/test/dll_main_test.cpp
+++ b/test/dll_main_test.cpp
@@ -10,7 +10,7 @@ using namespace winrt;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 // {358bb60e-2b77-4411-8a76-27164945c93d}
-constexpr GUID GUID_Random{0x358bb60e, 0x2b77, 0x4411, {0x8a, 0x76, 0x27, 0x16, 0x49, 0x45, 0xc9, 0x3d}};
+constexpr GUID random_class_id{0x358bb60e, 0x2b77, 0x4411, {0x8a, 0x76, 0x27, 0x16, 0x49, 0x45, 0xc9, 0x3d}};
 
 
 TEST_CLASS(dllmain_test)
@@ -18,7 +18,7 @@ TEST_CLASS(dllmain_test)
 public:
     TEST_METHOD(class_factory_netpbm_decoder_lock_server) // NOLINT
     {
-        const auto class_factory{factory_.get_class_factory(CLSID_NetPbmDecoder)};
+        const auto class_factory{factory_.get_class_factory(net_pbm_decoder_class_id)};
 
         hresult result{class_factory->LockServer(true)};
         Assert::AreEqual(error_ok, result);
@@ -29,28 +29,28 @@ public:
 
     TEST_METHOD(class_factory_unknown_id) // NOLINT
     {
-        winrt::com_ptr<IClassFactory> class_factory;
-        const hresult result{factory_.get_class_factory(GUID_Random, class_factory)};
+        com_ptr<IClassFactory> class_factory;
+        const hresult result{factory_.get_class_factory(random_class_id, class_factory)};
 
         Assert::AreEqual(error_class_not_available, result);
     }
 
     TEST_METHOD(class_factory_netpbm_decoder_create_instance_bad_result) // NOLINT
     {
-        const auto class_factory{factory_.get_class_factory(CLSID_NetPbmDecoder)};
+        const auto class_factory{factory_.get_class_factory(net_pbm_decoder_class_id)};
 
         SUPPRESS_WARNING_6387_INVALID_ARGUMENT_NEXT_LINE
-        const hresult result{class_factory->CreateInstance(nullptr, GUID_Random, nullptr)};
+        const hresult result{class_factory->CreateInstance(nullptr, random_class_id, nullptr)};
 
         Assert::AreEqual(error_pointer, result);
     }
 
     TEST_METHOD(class_factory_netpbm_decoder_create_instance_no_aggregation) // NOLINT
     {
-        const auto class_factory{factory_.get_class_factory(CLSID_NetPbmDecoder)};
+        const auto class_factory{factory_.get_class_factory(net_pbm_decoder_class_id)};
 
         auto outer = reinterpret_cast<IUnknown*>(1);
-        winrt::com_ptr<IWICBitmapDecoder> decoder;
+        com_ptr<IWICBitmapDecoder> decoder;
         const hresult result{class_factory->CreateInstance(outer, IID_PPV_ARGS(decoder.put()))};
 
         Assert::AreEqual(error_no_aggregation, result);

--- a/test/factory.ixx
+++ b/test/factory.ixx
@@ -8,7 +8,7 @@ module;
 
 export module factory;
 
-export inline constexpr GUID CLSID_NetPbmDecoder{0x6891bbe, 0xcc02, 0x4bb2, {0x9c, 0xf0, 0x30, 0x3f, 0xc4, 0xe6, 0x68, 0xc3}};
+export inline constexpr GUID net_pbm_decoder_class_id{0x6891bbe, 0xcc02, 0x4bb2, {0x9c, 0xf0, 0x30, 0x3f, 0xc4, 0xe6, 0x68, 0xc3}};
 
 export class factory final
 {
@@ -35,7 +35,7 @@ public:
     [[nodiscard]] winrt::com_ptr<IWICBitmapDecoder> create_decoder() const
     {
         winrt::com_ptr<IWICBitmapDecoder> decoder;
-        winrt::check_hresult(get_class_factory(CLSID_NetPbmDecoder)->CreateInstance(nullptr, IID_PPV_ARGS(decoder.put())));
+        winrt::check_hresult(get_class_factory(net_pbm_decoder_class_id)->CreateInstance(nullptr, IID_PPV_ARGS(decoder.put())));
 
         return decoder;
     }

--- a/test/portable_anymap_file.ixx
+++ b/test/portable_anymap_file.ixx
@@ -79,10 +79,8 @@ private:
     {
         std::vector<int> result;
 
-        const auto first = static_cast<char>(pnm_file.get());
-
         // All portable anymap format (PNM) start with the character P.
-        if (first != 'P')
+        if (const auto first = static_cast<char>(pnm_file.get()); first != 'P')
             throw std::istream::failure("Missing P");
 
         while (result.size() < 4)


### PR DESCRIPTION
C5246 is more an informal warning. It prevents "normal" use of std::array.