### PR TITLE
Use explicit VCToolsVersion=14.37.32822

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -18,7 +18,7 @@ jobs:
         buildConfiguration: [Release, Debug]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1.1.3
@@ -32,7 +32,7 @@ jobs:
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /v:m /m /p:Configuration=${{matrix.buildConfiguration}} /p:Platform=${{matrix.buildPlatform}} ${{env.SOLUTION_FILE_PATH}}
+      run: msbuild /v:m /m /p:Configuration=${{matrix.buildConfiguration}} /p:Platform=${{matrix.buildPlatform}} ${{env.SOLUTION_FILE_PATH}} /p:VCToolsVersion=14.37.32822
 
     - name: Test
       working-directory: .\build\bin\${{matrix.buildPlatform}}\${{matrix.buildConfiguration}}\


### PR DESCRIPTION
Visual Studio 2022 has a defect. If 2 toolsets are installed, the default is not the latest.

The only workaround is to explicit select the toolset to use.
Note: at the moment 17.7.2 is installed, which cannot compile modules correctly.