### PR TITLE
Use default C++/WinRT settings (remove WINRT_NO_MAKE_DETECTION)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -95,13 +95,12 @@
         NOMINMAX: Prevent that the Windows SDK header files define the macros min and max (conflict with C++ std::min\max).
 
         * WINRT *
-        WINRT_NO_MAKE_DETECTION: Enable making COM class implementation final
-        _SILENCE_CLANG_COROUTINE_MESSAGE: Supress warning that coroutine is not compatible wih clang (clang-tidy fix)
+        WINRT_LEAN_AND_MEAN: Disables rarely-used features (in order to reduce compile times)
 
         * Secure C Runtime *
         __STDC_WANT_SECURE_LIB__=1;
       -->
-      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOSERVICE;NOMCX;NOIME;NOMINMAX;WINRT_NO_MAKE_DETECTION;_SILENCE_CLANG_COROUTINE_MESSAGE;__STDC_WANT_SECURE_LIB__=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32_LEAN_AND_MEAN;NOSERVICE;NOMCX;NOIME;NOMINMAX;WINRT_LEAN_AND_MEAN;__STDC_WANT_SECURE_LIB__=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
 

--- a/netpbm-wic-codec.sln.DotSettings
+++ b/netpbm-wic-codec.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyBugproneBranchClone/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClassCanBeFinal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=anymap/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=bugprone/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CLSID/@EntryIndexedValue">True</s:Boolean>

--- a/src/netpbm_bitmap_decoder.cpp
+++ b/src/netpbm_bitmap_decoder.cpp
@@ -23,10 +23,10 @@ using winrt::check_hresult;
 using winrt::com_ptr;
 using winrt::to_hresult;
 
+namespace {
 
-class netpbm_bitmap_decoder final : public winrt::implements<netpbm_bitmap_decoder, IWICBitmapDecoder>
+struct netpbm_bitmap_decoder :  winrt::implements<netpbm_bitmap_decoder, IWICBitmapDecoder>
 {
-public:
     // IWICBitmapDecoder
     HRESULT __stdcall QueryCapability(_In_ IStream* stream, _Out_ DWORD* capability) noexcept override
     try
@@ -222,6 +222,7 @@ private:
     com_ptr<IWICBitmapFrameDecode> bitmap_frame_decode_;
 };
 
+} // namespace
 
 void create_netpbm_bitmap_decoder_factory(GUID const& interface_id, void** result)
 {

--- a/src/netpbm_bitmap_frame_decode.ixx
+++ b/src/netpbm_bitmap_frame_decode.ixx
@@ -11,26 +11,22 @@ import <std.h>;
 import <win.h>;
 import winrt;
 
-export class netpbm_bitmap_frame_decode final
-    : public winrt::implements<netpbm_bitmap_frame_decode, IWICBitmapFrameDecode, IWICBitmapSource>
+export struct netpbm_bitmap_frame_decode
+    : winrt::implements<netpbm_bitmap_frame_decode, IWICBitmapFrameDecode, IWICBitmapSource>
 {
-public:
     netpbm_bitmap_frame_decode(_In_ IStream* source_stream, _In_ IWICImagingFactory* factory);
 
     // IWICBitmapSource
     HRESULT __stdcall GetSize(uint32_t* width, uint32_t* height) override;
     HRESULT __stdcall GetPixelFormat(GUID* pixel_format) override;
     HRESULT __stdcall GetResolution(double* dpi_x, double* dpi_y) override;
-    HRESULT __stdcall CopyPixels(const WICRect* rectangle, uint32_t stride, uint32_t buffer_size,
-                                 BYTE* buffer) override;
+    HRESULT __stdcall CopyPixels(const WICRect* rectangle, uint32_t stride, uint32_t buffer_size, BYTE* buffer) override;
     HRESULT __stdcall CopyPalette(IWICPalette*) noexcept override;
 
     // IWICBitmapFrameDecode : IWICBitmapSource
     HRESULT __stdcall GetThumbnail(IWICBitmapSource**) noexcept override;
-    HRESULT __stdcall GetColorContexts(uint32_t count, IWICColorContext** color_contexts,
-                                       uint32_t* actual_count) override;
-    HRESULT __stdcall GetMetadataQueryReader(IWICMetadataQueryReader** metadata_query_reader)
-        noexcept override;
+    HRESULT __stdcall GetColorContexts(uint32_t count, IWICColorContext** color_contexts, uint32_t* actual_count) override;
+    HRESULT __stdcall GetMetadataQueryReader(IWICMetadataQueryReader** metadata_query_reader) noexcept override;
 
 private:
     winrt::com_ptr<IWICBitmapSource> bitmap_source_;

--- a/test/test_stream.ixx
+++ b/test/test_stream.ixx
@@ -12,9 +12,8 @@ import test.winrt;
 
 import test.errors;
 
-export class test_stream final : public winrt::implements<test_stream, IStream>
+export struct test_stream : winrt::implements<test_stream, IStream>
 {
-public:
     test_stream(const bool fail_on_read, int fail_on_seek_counter) noexcept :
         fail_on_read_{fail_on_read}, fail_on_seek_counter_{fail_on_seek_counter}
     {


### PR DESCRIPTION
WINRT_NO_MAKE_DETECTION ensure that winrt::make must be used, but prevent using final on the implementation classes. As is not a default option, it may confuss others.