### PR TITLE
Remove explicit -p:VCToolsVersion=14.38.33130  in CI build pipeline

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Build
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /v:m /m /p:Configuration=${{matrix.buildConfiguration}} /p:Platform=${{matrix.buildPlatform}} ${{env.SOLUTION_FILE_PATH}} /p:VCToolsVersion=14.38.33130
+      run: msbuild /v:m /m /p:Configuration=${{matrix.buildConfiguration}} /p:Platform=${{matrix.buildPlatform}} ${{env.SOLUTION_FILE_PATH}} /p:NETPBM_WIC_CODEC_ALL_WARNINGS=true
 
     - name: Test
       working-directory: .\build\bin\${{matrix.buildPlatform}}\${{matrix.buildConfiguration}}\


### PR DESCRIPTION
Due to several issues github\azure decided to only make the latest build tools available.
There is no longer a need to explicit control (which was needed) which build tool to use to ensure that the latest one was selected.

Note: also enable NETPBM_WIC_CODEC_ALL_WARNINGS