### PR TITLE
Mark the generated DLL with OLESelfRegister in the StringFileInfo

### DIFF
--- a/src/netpbm-wic-codec.rc
+++ b/src/netpbm-wic-codec.rc
@@ -34,6 +34,7 @@ BEGIN
             VALUE "OriginalFilename", L"netpbm-wic-codec.dll"
             VALUE "ProductName", L"Netpbm WIC codec"
             VALUE "ProductVersion", VERSION
+            VALUE "OLESelfRegister", "\0"
         END
     END
     BLOCK "VarFileInfo"

--- a/std-header-units/std-header-units.vcxproj.filters
+++ b/std-header-units/std-header-units.vcxproj.filters
@@ -9,10 +9,6 @@
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
     </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="generate_header_units.cpp">

--- a/test/dll_main_test.cpp
+++ b/test/dll_main_test.cpp
@@ -3,6 +3,7 @@
 
 #include "util.h"
 
+import <std.h>;
 import <win.h>;
 import test.winrt;
 import test.errors;
@@ -55,6 +56,23 @@ public:
         const auto result{class_factory->CreateInstance(outer, IID_PPV_ARGS(decoder.put()))};
 
         Assert::AreEqual(error_no_aggregation, result);
+    }
+
+    TEST_METHOD(marked_for_self_registration) // NOLINT
+    {
+        const wchar_t dll_name[]{L"netpbm-wic-codec.dll"};
+        DWORD not_used;
+        const DWORD size{GetFileVersionInfoSizeEx(FILE_VER_GET_NEUTRAL, dll_name, &not_used)};
+        Assert::IsTrue(size != 0);
+
+        std::vector<std::byte> buffer(size);
+        bool result = GetFileVersionInfoEx(FILE_VER_GET_NEUTRAL, dll_name, 0, size, buffer.data());
+        Assert::IsTrue(result);
+
+        void* value;
+        UINT value_size;
+        result = VerQueryValue(buffer.data(), L"\\StringFileInfo\\000004b0\\OLESelfRegister", &value, &value_size);
+        Assert::IsTrue(result);
     }
 
 private:

--- a/test/factory.ixx
+++ b/test/factory.ixx
@@ -3,7 +3,7 @@
 
 export module factory;
 
-import "win.h";
+import <win.h>;
 import test.winrt;
 
 export inline constexpr GUID net_pbm_decoder_class_id{0x6891bbe, 0xcc02, 0x4bb2, {0x9c, 0xf0, 0x30, 0x3f, 0xc4, 0xe6, 0x68, 0xc3}};


### PR DESCRIPTION
The DLL provides the function DllRegisterServer for COM registration. To indicate that is has this method it should also include the value OLESelfRegister in the StringFileInfo